### PR TITLE
Fix vulnerabilities and update database

### DIFF
--- a/data/referers.json
+++ b/data/referers.json
@@ -1,10 +1,5 @@
 {
     "unknown": {
-        "Outbrain": {
-            "domains": [
-                "paid.outbrain.com"
-            ]
-        }, 
         "Google": {
             "domains": [
                 "support.google.com", 
@@ -14,14 +9,19 @@
                 "drive.google.com", 
                 "sites.google.com", 
                 "groups.google.com", 
-                "groups.google.co.uk", 
-                "news.google.co.uk"
+                "groups.google.co.uk"
             ]
         }, 
-        "Taboola": {
+        "Yandex Maps": {
             "domains": [
-                "trc.taboola.com", 
-                "api.taboola.com"
+                "maps.yandex.ru", 
+                "maps.yandex.ua", 
+                "maps.yandex.com", 
+                "maps.yandex.by", 
+                "n.maps.yandex.ru"
+            ], 
+            "parameters": [
+                "text"
             ]
         }, 
         "Yahoo!": {
@@ -139,6 +139,14 @@
                 "q"
             ]
         }, 
+        "2gis": {
+            "domains": [
+                "2gis.ru", 
+                "www.2gis.ru", 
+                "link.2gis.ru", 
+                "www.link.2gis.ru"
+            ]
+        }, 
         "Lo.st": {
             "domains": [
                 "lo.st"
@@ -183,6 +191,14 @@
                 "qs"
             ]
         }, 
+        "Telstra": {
+            "domains": [
+                "search.media.telstra.com.au"
+            ], 
+            "parameters": [
+                "find"
+            ]
+        }, 
         "Web.nl": {
             "domains": [
                 "www.web.nl"
@@ -218,6 +234,7 @@
                 "www.aolimages.aol.fr", 
                 "aim.search.aol.com", 
                 "www.recherche.aol.fr", 
+                "recherche.aol.fr", 
                 "find.web.aol.com", 
                 "recherche.aol.ca", 
                 "aolsearch.aol.co.uk", 
@@ -309,6 +326,14 @@
             ], 
             "parameters": [
                 "q"
+            ]
+        }, 
+        "Arcor": {
+            "domains": [
+                "www.arcor.de"
+            ], 
+            "parameters": [
+                "Keywords"
             ]
         }, 
         "arama": {
@@ -626,7 +651,6 @@
                 "images.google.com.hk", 
                 "images.google.com.jm", 
                 "images.google.com.kh", 
-                "images.google.com.kh", 
                 "images.google.com.kw", 
                 "images.google.com.lb", 
                 "images.google.com.lc", 
@@ -745,8 +769,7 @@
                 "images.google.tt", 
                 "images.google.us", 
                 "images.google.vg", 
-                "images.google.vu", 
-                "images.google.ws"
+                "images.google.vu"
             ], 
             "parameters": [
                 "q"
@@ -838,7 +861,6 @@
                 "google.com.gt/products", 
                 "google.com.hk/products", 
                 "google.com.jm/products", 
-                "google.com.kh/products", 
                 "google.com.kh/products", 
                 "google.com.kw/products", 
                 "google.com.lb/products", 
@@ -1036,7 +1058,6 @@
                 "www.google.com.hk/products", 
                 "www.google.com.jm/products", 
                 "www.google.com.kh/products", 
-                "www.google.com.kh/products", 
                 "www.google.com.kw/products", 
                 "www.google.com.lb/products", 
                 "www.google.com.lc/products", 
@@ -1206,20 +1227,20 @@
                 "searchTerm"
             ]
         }, 
+        "British Telecommunications": {
+            "domains": [
+                "search.bt.com"
+            ], 
+            "parameters": [
+                "p"
+            ]
+        }, 
         "Neti": {
             "domains": [
                 "www.neti.ee"
             ], 
             "parameters": [
                 "query"
-            ]
-        }, 
-        "Winamp": {
-            "domains": [
-                "search.winamp.com"
-            ], 
-            "parameters": [
-                "q"
             ]
         }, 
         "Nigma": {
@@ -1273,6 +1294,23 @@
                 "key"
             ]
         }, 
+        "Flyingbird": {
+            "domains": [
+                "inspsearch.com", 
+                "viview.inspsearch.com"
+            ], 
+            "parameters": [
+                "q"
+            ]
+        }, 
+        "Everyclick": {
+            "domains": [
+                "www.everyclick.com"
+            ], 
+            "parameters": [
+                "keyword"
+            ]
+        }, 
         "Wirtualna Polska": {
             "domains": [
                 "szukaj.wp.pl"
@@ -1307,10 +1345,24 @@
                 "www.yandex.ru", 
                 "www.yandex.ua", 
                 "www.yandex.com", 
-                "www.yandex.by"
+                "www.yandex.by", 
+                "clck.yandex.ru", 
+                "clck.yandex.ua", 
+                "clck.yandex.com", 
+                "clck.yandex.by"
             ], 
             "parameters": [
                 "text"
+            ]
+        }, 
+        "Indeed": {
+            "domains": [
+                "de.indeed.com", 
+                "at.indeed.com", 
+                "fr.indeed.com", 
+                "it.indeed.com", 
+                "ch.indeed.com", 
+                "au.indeed.com"
             ]
         }, 
         "canoe.ca": {
@@ -1378,6 +1430,17 @@
                 "q"
             ]
         }, 
+        "StepStone": {
+            "domains": [
+                "www.stepstone.de", 
+                "www.stepstone.at", 
+                "www.stepstone.be", 
+                "www.stepstone.fr", 
+                "www.stepstone.nl", 
+                "www.stepstone.dk", 
+                "www.stepstone.se"
+            ]
+        }, 
         "Jungle Spider": {
             "domains": [
                 "www.jungle-spider.de"
@@ -1389,6 +1452,15 @@
         "PeoplePC": {
             "domains": [
                 "search.peoplepc.com"
+            ], 
+            "parameters": [
+                "q"
+            ]
+        }, 
+        "The Smart Search": {
+            "domains": [
+                "thesmartsearch.net", 
+                "www.thesmartsearch.net"
             ], 
             "parameters": [
                 "q"
@@ -1407,15 +1479,25 @@
         "Orange": {
             "domains": [
                 "busca.orange.es", 
-                "search.orange.co.uk"
+                "search.orange.co.uk", 
+                "lemoteur.orange.fr"
             ], 
             "parameters": [
-                "q"
+                "q", 
+                "kw"
             ]
         }, 
         "Gule Sider": {
             "domains": [
                 "www.gulesider.no"
+            ], 
+            "parameters": [
+                "q"
+            ]
+        }, 
+        "I.ua": {
+            "domains": [
+                "search.i.ua"
             ], 
             "parameters": [
                 "q"
@@ -1435,6 +1517,14 @@
             ], 
             "parameters": [
                 "searchfor"
+            ]
+        }, 
+        "Tut.by": {
+            "domains": [
+                "search.tut.by"
+            ], 
+            "parameters": [
+                "query"
             ]
         }, 
         "Trusted-Search": {
@@ -1462,12 +1552,12 @@
                 "q"
             ]
         }, 
-        "Blogpulse": {
+        "kununu": {
             "domains": [
-                "www.blogpulse.com"
+                "kununu.com"
             ], 
             "parameters": [
-                "query"
+                "q"
             ]
         }, 
         "Volny": {
@@ -1554,9 +1644,9 @@
                 "keyword"
             ]
         }, 
-        "Suchnase": {
+        "Inbox.com": {
             "domains": [
-                "www.suchnase.de"
+                "inbox.com/search/"
             ], 
             "parameters": [
                 "q"
@@ -1571,9 +1661,228 @@
                 "Keywords"
             ]
         }, 
+        "Suchnase": {
+            "domains": [
+                "www.suchnase.de"
+            ], 
+            "parameters": [
+                "q"
+            ]
+        }, 
+        "Dodo": {
+            "domains": [
+                "google.dodo.com.au"
+            ], 
+            "parameters": [
+                "q"
+            ]
+        }, 
+        "Google Blogsearch": {
+            "domains": [
+                "blogsearch.google.ac", 
+                "blogsearch.google.ad", 
+                "blogsearch.google.ae", 
+                "blogsearch.google.am", 
+                "blogsearch.google.as", 
+                "blogsearch.google.at", 
+                "blogsearch.google.az", 
+                "blogsearch.google.ba", 
+                "blogsearch.google.be", 
+                "blogsearch.google.bf", 
+                "blogsearch.google.bg", 
+                "blogsearch.google.bi", 
+                "blogsearch.google.bj", 
+                "blogsearch.google.bs", 
+                "blogsearch.google.by", 
+                "blogsearch.google.ca", 
+                "blogsearch.google.cat", 
+                "blogsearch.google.cc", 
+                "blogsearch.google.cd", 
+                "blogsearch.google.cf", 
+                "blogsearch.google.cg", 
+                "blogsearch.google.ch", 
+                "blogsearch.google.ci", 
+                "blogsearch.google.cl", 
+                "blogsearch.google.cm", 
+                "blogsearch.google.cn", 
+                "blogsearch.google.co.bw", 
+                "blogsearch.google.co.ck", 
+                "blogsearch.google.co.cr", 
+                "blogsearch.google.co.id", 
+                "blogsearch.google.co.il", 
+                "blogsearch.google.co.in", 
+                "blogsearch.google.co.jp", 
+                "blogsearch.google.co.ke", 
+                "blogsearch.google.co.kr", 
+                "blogsearch.google.co.ls", 
+                "blogsearch.google.co.ma", 
+                "blogsearch.google.co.mz", 
+                "blogsearch.google.co.nz", 
+                "blogsearch.google.co.th", 
+                "blogsearch.google.co.tz", 
+                "blogsearch.google.co.ug", 
+                "blogsearch.google.co.uk", 
+                "blogsearch.google.co.uz", 
+                "blogsearch.google.co.ve", 
+                "blogsearch.google.co.vi", 
+                "blogsearch.google.co.za", 
+                "blogsearch.google.co.zm", 
+                "blogsearch.google.co.zw", 
+                "blogsearch.google.com", 
+                "blogsearch.google.com.af", 
+                "blogsearch.google.com.ag", 
+                "blogsearch.google.com.ai", 
+                "blogsearch.google.com.ar", 
+                "blogsearch.google.com.au", 
+                "blogsearch.google.com.bd", 
+                "blogsearch.google.com.bh", 
+                "blogsearch.google.com.bn", 
+                "blogsearch.google.com.bo", 
+                "blogsearch.google.com.br", 
+                "blogsearch.google.com.by", 
+                "blogsearch.google.com.bz", 
+                "blogsearch.google.com.co", 
+                "blogsearch.google.com.cu", 
+                "blogsearch.google.com.cy", 
+                "blogsearch.google.com.do", 
+                "blogsearch.google.com.ec", 
+                "blogsearch.google.com.eg", 
+                "blogsearch.google.com.et", 
+                "blogsearch.google.com.fj", 
+                "blogsearch.google.com.gh", 
+                "blogsearch.google.com.gi", 
+                "blogsearch.google.com.gt", 
+                "blogsearch.google.com.hk", 
+                "blogsearch.google.com.jm", 
+                "blogsearch.google.com.kh", 
+                "blogsearch.google.com.kw", 
+                "blogsearch.google.com.lb", 
+                "blogsearch.google.com.lc", 
+                "blogsearch.google.com.ly", 
+                "blogsearch.google.com.mt", 
+                "blogsearch.google.com.mx", 
+                "blogsearch.google.com.my", 
+                "blogsearch.google.com.na", 
+                "blogsearch.google.com.nf", 
+                "blogsearch.google.com.ng", 
+                "blogsearch.google.com.ni", 
+                "blogsearch.google.com.np", 
+                "blogsearch.google.com.om", 
+                "blogsearch.google.com.pa", 
+                "blogsearch.google.com.pe", 
+                "blogsearch.google.com.ph", 
+                "blogsearch.google.com.pk", 
+                "blogsearch.google.com.pr", 
+                "blogsearch.google.com.py", 
+                "blogsearch.google.com.qa", 
+                "blogsearch.google.com.sa", 
+                "blogsearch.google.com.sb", 
+                "blogsearch.google.com.sg", 
+                "blogsearch.google.com.sl", 
+                "blogsearch.google.com.sv", 
+                "blogsearch.google.com.tj", 
+                "blogsearch.google.com.tn", 
+                "blogsearch.google.com.tr", 
+                "blogsearch.google.com.tw", 
+                "blogsearch.google.com.ua", 
+                "blogsearch.google.com.uy", 
+                "blogsearch.google.com.vc", 
+                "blogsearch.google.com.vn", 
+                "blogsearch.google.cv", 
+                "blogsearch.google.cz", 
+                "blogsearch.google.de", 
+                "blogsearch.google.dj", 
+                "blogsearch.google.dk", 
+                "blogsearch.google.dm", 
+                "blogsearch.google.dz", 
+                "blogsearch.google.ee", 
+                "blogsearch.google.es", 
+                "blogsearch.google.fi", 
+                "blogsearch.google.fm", 
+                "blogsearch.google.fr", 
+                "blogsearch.google.ga", 
+                "blogsearch.google.gd", 
+                "blogsearch.google.ge", 
+                "blogsearch.google.gf", 
+                "blogsearch.google.gg", 
+                "blogsearch.google.gl", 
+                "blogsearch.google.gm", 
+                "blogsearch.google.gp", 
+                "blogsearch.google.gr", 
+                "blogsearch.google.gy", 
+                "blogsearch.google.hn", 
+                "blogsearch.google.hr", 
+                "blogsearch.google.ht", 
+                "blogsearch.google.hu", 
+                "blogsearch.google.ie", 
+                "blogsearch.google.im", 
+                "blogsearch.google.io", 
+                "blogsearch.google.iq", 
+                "blogsearch.google.is", 
+                "blogsearch.google.it", 
+                "blogsearch.google.it.ao", 
+                "blogsearch.google.je", 
+                "blogsearch.google.jo", 
+                "blogsearch.google.kg", 
+                "blogsearch.google.ki", 
+                "blogsearch.google.kz", 
+                "blogsearch.google.la", 
+                "blogsearch.google.li", 
+                "blogsearch.google.lk", 
+                "blogsearch.google.lt", 
+                "blogsearch.google.lu", 
+                "blogsearch.google.lv", 
+                "blogsearch.google.md", 
+                "blogsearch.google.me", 
+                "blogsearch.google.mg", 
+                "blogsearch.google.mk", 
+                "blogsearch.google.ml", 
+                "blogsearch.google.mn", 
+                "blogsearch.google.ms", 
+                "blogsearch.google.mu", 
+                "blogsearch.google.mv", 
+                "blogsearch.google.mw", 
+                "blogsearch.google.ne", 
+                "blogsearch.google.nl", 
+                "blogsearch.google.no", 
+                "blogsearch.google.nr", 
+                "blogsearch.google.nu", 
+                "blogsearch.google.pl", 
+                "blogsearch.google.pn", 
+                "blogsearch.google.ps", 
+                "blogsearch.google.pt", 
+                "blogsearch.google.ro", 
+                "blogsearch.google.rs", 
+                "blogsearch.google.ru", 
+                "blogsearch.google.rw", 
+                "blogsearch.google.sc", 
+                "blogsearch.google.se", 
+                "blogsearch.google.sh", 
+                "blogsearch.google.si", 
+                "blogsearch.google.sk", 
+                "blogsearch.google.sm", 
+                "blogsearch.google.sn", 
+                "blogsearch.google.so", 
+                "blogsearch.google.st", 
+                "blogsearch.google.td", 
+                "blogsearch.google.tg", 
+                "blogsearch.google.tk", 
+                "blogsearch.google.tl", 
+                "blogsearch.google.tm", 
+                "blogsearch.google.to", 
+                "blogsearch.google.tt", 
+                "blogsearch.google.us", 
+                "blogsearch.google.vg", 
+                "blogsearch.google.vu", 
+                "blogsearch.google.ws"
+            ], 
+            "parameters": [
+                "q"
+            ]
+        }, 
         "Poisk.ru": {
             "domains": [
-                "www.plazoo.com"
+                "poisk.ru"
             ], 
             "parameters": [
                 "q"
@@ -1585,6 +1894,14 @@
             ], 
             "parameters": [
                 "keyword"
+            ]
+        }, 
+        "Finderoo": {
+            "domains": [
+                "www.finderoo.com"
+            ], 
+            "parameters": [
+                "q"
             ]
         }, 
         "Najdi": {
@@ -1605,6 +1922,8 @@
         }, 
         "Mail.ru": {
             "domains": [
+                "mail.ru", 
+                "m.mail.ru", 
                 "go.mail.ru"
             ], 
             "parameters": [
@@ -1712,12 +2031,12 @@
                 "query"
             ]
         }, 
-        "Gomeo": {
+        "Clix": {
             "domains": [
-                "www.gomeo.com"
+                "pesquisa.clix.pt"
             ], 
             "parameters": [
-                "Keywords"
+                "question"
             ]
         }, 
         "Walhello": {
@@ -1791,6 +2110,7 @@
         }, 
         "MySearch": {
             "domains": [
+                "mysearch.com", 
                 "www.mysearch.com", 
                 "ms114.mysearch.com", 
                 "ms146.mysearch.com", 
@@ -1836,12 +2156,12 @@
                 "keyword"
             ]
         }, 
-        "Arcor": {
+        "Lilo": {
             "domains": [
-                "www.arcor.de"
+                "search.lilo.org"
             ], 
             "parameters": [
-                "Keywords"
+                "q"
             ]
         }, 
         "Naver": {
@@ -1927,7 +2247,8 @@
                 "zhidao.baidu.com", 
                 "tieba.baidu.com", 
                 "news.baidu.com", 
-                "web.gougou.com"
+                "web.gougou.com", 
+                "m.baidu.com"
             ], 
             "parameters": [
                 "wd", 
@@ -1965,6 +2286,14 @@
         "TrovaRapido": {
             "domains": [
                 "www.trovarapido.com"
+            ], 
+            "parameters": [
+                "q"
+            ]
+        }, 
+        "Winamp": {
+            "domains": [
+                "search.winamp.com"
             ], 
             "parameters": [
                 "q"
@@ -2043,18 +2372,13 @@
                 "string"
             ]
         }, 
-        "Bing": {
+        "Qwant": {
             "domains": [
-                "bing.com", 
-                "www.bing.com", 
-                "msnbc.msn.com", 
-                "dizionario.it.msn.com", 
-                "cc.bingj.com", 
-                "m.bing.com"
+                "www.qwant.com", 
+                "lite.qwant.com"
             ], 
             "parameters": [
-                "q", 
-                "Q"
+                "q"
             ]
         }, 
         "X-recherche": {
@@ -2069,7 +2393,8 @@
             "domains": [
                 "images.yandex.ru", 
                 "images.yandex.ua", 
-                "images.yandex.com"
+                "images.yandex.com", 
+                "images.yandex.by"
             ], 
             "parameters": [
                 "text"
@@ -2092,13 +2417,18 @@
                 "q"
             ]
         }, 
-        "Jungle Key": {
+        "Shenma": {
             "domains": [
-                "junglekey.com", 
-                "junglekey.fr"
+                "so.m.sm.cn", 
+                "yz.m.sm.cn", 
+                "m.sm.cn", 
+                "quark.sm.cn", 
+                "m.sp.sm.cn", 
+                "m.yz2.sm.cn", 
+                "m.yz.sm.cn"
             ], 
             "parameters": [
-                "query"
+                "q"
             ]
         }, 
         "Firstfind": {
@@ -2194,6 +2524,14 @@
                 "q"
             ]
         }, 
+        "Liveinternet": {
+            "domains": [
+                "liveinternet.ru"
+            ], 
+            "parameters": [
+                "q"
+            ]
+        }, 
         "Meinestadt": {
             "domains": [
                 "www.meinestadt.de"
@@ -2221,6 +2559,14 @@
         "Snapdo": {
             "domains": [
                 "search.snapdo.com"
+            ], 
+            "parameters": [
+                "q"
+            ]
+        }, 
+        "UKR.net": {
+            "domains": [
+                "search.ukr.net"
             ], 
             "parameters": [
                 "q"
@@ -2335,7 +2681,6 @@
                 "news.google.com.gt", 
                 "news.google.com.hk", 
                 "news.google.com.jm", 
-                "news.google.com.kh", 
                 "news.google.com.kh", 
                 "news.google.com.kw", 
                 "news.google.com.lb", 
@@ -2552,9 +2897,34 @@
                 "q"
             ]
         }, 
+        "Search This": {
+            "domains": [
+                "www.searchthis.com"
+            ], 
+            "parameters": [
+                "q"
+            ]
+        }, 
         "DuckDuckGo": {
             "domains": [
                 "duckduckgo.com"
+            ], 
+            "parameters": [
+                "q"
+            ]
+        }, 
+        "Monster": {
+            "domains": [
+                "www.monster.be", 
+                "www.monster.cz", 
+                "www.monster.de", 
+                "www.monster.fi", 
+                "www.monster.fr", 
+                "www.monster.ie", 
+                "www.monster.it", 
+                "www.monster.lu", 
+                "www.monster.ch", 
+                "www.monster.co.uk"
             ], 
             "parameters": [
                 "q"
@@ -2585,6 +2955,15 @@
                 "q"
             ]
         }, 
+        "SoSoDesk": {
+            "domains": [
+                "sosodesktop.com", 
+                "search.sosodesktop.com"
+            ], 
+            "parameters": [
+                "q"
+            ]
+        }, 
         "Excite": {
             "domains": [
                 "search.excite.it", 
@@ -2599,6 +2978,14 @@
             "parameters": [
                 "q", 
                 "search"
+            ]
+        }, 
+        "1&1": {
+            "domains": [
+                "search.1and1.com"
+            ], 
+            "parameters": [
+                "q"
             ]
         }, 
         "qip": {
@@ -2627,6 +3014,8 @@
                 "au.yahoo.com", 
                 "br.search.yahoo.com", 
                 "br.yahoo.com", 
+                "ca.search.yahoo.com", 
+                "ca.yahoo.com", 
                 "cade.searchde.yahoo.com", 
                 "cade.yahoo.com", 
                 "chinese.searchinese.yahoo.com", 
@@ -2640,13 +3029,15 @@
                 "es.search.yahoo.com", 
                 "es.yahoo.com", 
                 "espanol.searchpanol.yahoo.com", 
-                "espanol.searchpanol.yahoo.com", 
-                "espanol.yahoo.com", 
                 "espanol.yahoo.com", 
                 "fr.search.yahoo.com", 
                 "fr.yahoo.com", 
+                "hk.search.yahoo.com", 
+                "hk.yahoo.com", 
                 "ie.search.yahoo.com", 
                 "ie.yahoo.com", 
+                "in.search.yahoo.com", 
+                "in.yahoo.com", 
                 "it.search.yahoo.com", 
                 "it.yahoo.com", 
                 "kr.search.yahoo.com", 
@@ -2660,17 +3051,18 @@
                 "one.cn.yahoo.com", 
                 "one.searchn.yahoo.com", 
                 "qc.search.yahoo.com", 
-                "qc.search.yahoo.com", 
-                "qc.search.yahoo.com", 
                 "qc.yahoo.com", 
-                "qc.yahoo.com", 
-                "se.search.yahoo.com", 
+                "ru.search.yahoo.com", 
+                "ru.yahoo.com", 
                 "se.search.yahoo.com", 
                 "se.yahoo.com", 
                 "search.searcharch.yahoo.com", 
-                "search.yahoo.com", 
+                "tw.search.yahoo.com", 
+                "tw.yahoo.com", 
                 "uk.search.yahoo.com", 
                 "uk.yahoo.com", 
+                "us.search.yahoo.com", 
+                "us.yahoo.com", 
                 "www.yahoo.co.jp", 
                 "search.yahoo.co.jp", 
                 "www.cercato.it", 
@@ -2755,12 +3147,18 @@
                 "q"
             ]
         }, 
-        "Everyclick": {
+        "Bing": {
             "domains": [
-                "www.everyclick.com"
+                "bing.com", 
+                "www.bing.com", 
+                "msnbc.msn.com", 
+                "dizionario.it.msn.com", 
+                "cc.bingj.com", 
+                "m.bing.com"
             ], 
             "parameters": [
-                "keyword"
+                "q", 
+                "Q"
             ]
         }, 
         "Google Video": {
@@ -2967,7 +3365,6 @@
                 "www.google.jo", 
                 "www.google.co.jp", 
                 "www.google.co.ke", 
-                "www.google.com.kh", 
                 "www.google.ki", 
                 "www.google.kg", 
                 "www.google.co.kr", 
@@ -3048,6 +3445,7 @@
                 "www.google.tm", 
                 "www.google.to", 
                 "www.google.com.tn", 
+                "www.google.tn", 
                 "www.google.com.tr", 
                 "www.google.tt", 
                 "www.google.com.tw", 
@@ -3164,7 +3562,6 @@
                 "google.jo", 
                 "google.co.jp", 
                 "google.co.ke", 
-                "google.com.kh", 
                 "google.ki", 
                 "google.kg", 
                 "google.co.kr", 
@@ -3266,6 +3663,7 @@
                 "google.co.za", 
                 "google.co.zm", 
                 "google.co.zw", 
+                "google.tn", 
                 "search.avg.com", 
                 "isearch.avg.com", 
                 "www.cnn.com", 
@@ -3299,208 +3697,12 @@
                 "Keywords"
             ]
         }, 
-        "Google Blogsearch": {
+        "Blogpulse": {
             "domains": [
-                "blogsearch.google.ac", 
-                "blogsearch.google.ad", 
-                "blogsearch.google.ae", 
-                "blogsearch.google.am", 
-                "blogsearch.google.as", 
-                "blogsearch.google.at", 
-                "blogsearch.google.az", 
-                "blogsearch.google.ba", 
-                "blogsearch.google.be", 
-                "blogsearch.google.bf", 
-                "blogsearch.google.bg", 
-                "blogsearch.google.bi", 
-                "blogsearch.google.bj", 
-                "blogsearch.google.bs", 
-                "blogsearch.google.by", 
-                "blogsearch.google.ca", 
-                "blogsearch.google.cat", 
-                "blogsearch.google.cc", 
-                "blogsearch.google.cd", 
-                "blogsearch.google.cf", 
-                "blogsearch.google.cg", 
-                "blogsearch.google.ch", 
-                "blogsearch.google.ci", 
-                "blogsearch.google.cl", 
-                "blogsearch.google.cm", 
-                "blogsearch.google.cn", 
-                "blogsearch.google.co.bw", 
-                "blogsearch.google.co.ck", 
-                "blogsearch.google.co.cr", 
-                "blogsearch.google.co.id", 
-                "blogsearch.google.co.il", 
-                "blogsearch.google.co.in", 
-                "blogsearch.google.co.jp", 
-                "blogsearch.google.co.ke", 
-                "blogsearch.google.co.kr", 
-                "blogsearch.google.co.ls", 
-                "blogsearch.google.co.ma", 
-                "blogsearch.google.co.mz", 
-                "blogsearch.google.co.nz", 
-                "blogsearch.google.co.th", 
-                "blogsearch.google.co.tz", 
-                "blogsearch.google.co.ug", 
-                "blogsearch.google.co.uk", 
-                "blogsearch.google.co.uz", 
-                "blogsearch.google.co.ve", 
-                "blogsearch.google.co.vi", 
-                "blogsearch.google.co.za", 
-                "blogsearch.google.co.zm", 
-                "blogsearch.google.co.zw", 
-                "blogsearch.google.com", 
-                "blogsearch.google.com.af", 
-                "blogsearch.google.com.ag", 
-                "blogsearch.google.com.ai", 
-                "blogsearch.google.com.ar", 
-                "blogsearch.google.com.au", 
-                "blogsearch.google.com.bd", 
-                "blogsearch.google.com.bh", 
-                "blogsearch.google.com.bn", 
-                "blogsearch.google.com.bo", 
-                "blogsearch.google.com.br", 
-                "blogsearch.google.com.by", 
-                "blogsearch.google.com.bz", 
-                "blogsearch.google.com.co", 
-                "blogsearch.google.com.cu", 
-                "blogsearch.google.com.cy", 
-                "blogsearch.google.com.do", 
-                "blogsearch.google.com.ec", 
-                "blogsearch.google.com.eg", 
-                "blogsearch.google.com.et", 
-                "blogsearch.google.com.fj", 
-                "blogsearch.google.com.gh", 
-                "blogsearch.google.com.gi", 
-                "blogsearch.google.com.gt", 
-                "blogsearch.google.com.hk", 
-                "blogsearch.google.com.jm", 
-                "blogsearch.google.com.kh", 
-                "blogsearch.google.com.kh", 
-                "blogsearch.google.com.kw", 
-                "blogsearch.google.com.lb", 
-                "blogsearch.google.com.lc", 
-                "blogsearch.google.com.ly", 
-                "blogsearch.google.com.mt", 
-                "blogsearch.google.com.mx", 
-                "blogsearch.google.com.my", 
-                "blogsearch.google.com.na", 
-                "blogsearch.google.com.nf", 
-                "blogsearch.google.com.ng", 
-                "blogsearch.google.com.ni", 
-                "blogsearch.google.com.np", 
-                "blogsearch.google.com.om", 
-                "blogsearch.google.com.pa", 
-                "blogsearch.google.com.pe", 
-                "blogsearch.google.com.ph", 
-                "blogsearch.google.com.pk", 
-                "blogsearch.google.com.pr", 
-                "blogsearch.google.com.py", 
-                "blogsearch.google.com.qa", 
-                "blogsearch.google.com.sa", 
-                "blogsearch.google.com.sb", 
-                "blogsearch.google.com.sg", 
-                "blogsearch.google.com.sl", 
-                "blogsearch.google.com.sv", 
-                "blogsearch.google.com.tj", 
-                "blogsearch.google.com.tn", 
-                "blogsearch.google.com.tr", 
-                "blogsearch.google.com.tw", 
-                "blogsearch.google.com.ua", 
-                "blogsearch.google.com.uy", 
-                "blogsearch.google.com.vc", 
-                "blogsearch.google.com.vn", 
-                "blogsearch.google.cv", 
-                "blogsearch.google.cz", 
-                "blogsearch.google.de", 
-                "blogsearch.google.dj", 
-                "blogsearch.google.dk", 
-                "blogsearch.google.dm", 
-                "blogsearch.google.dz", 
-                "blogsearch.google.ee", 
-                "blogsearch.google.es", 
-                "blogsearch.google.fi", 
-                "blogsearch.google.fm", 
-                "blogsearch.google.fr", 
-                "blogsearch.google.ga", 
-                "blogsearch.google.gd", 
-                "blogsearch.google.ge", 
-                "blogsearch.google.gf", 
-                "blogsearch.google.gg", 
-                "blogsearch.google.gl", 
-                "blogsearch.google.gm", 
-                "blogsearch.google.gp", 
-                "blogsearch.google.gr", 
-                "blogsearch.google.gy", 
-                "blogsearch.google.hn", 
-                "blogsearch.google.hr", 
-                "blogsearch.google.ht", 
-                "blogsearch.google.hu", 
-                "blogsearch.google.ie", 
-                "blogsearch.google.im", 
-                "blogsearch.google.io", 
-                "blogsearch.google.iq", 
-                "blogsearch.google.is", 
-                "blogsearch.google.it", 
-                "blogsearch.google.it.ao", 
-                "blogsearch.google.je", 
-                "blogsearch.google.jo", 
-                "blogsearch.google.kg", 
-                "blogsearch.google.ki", 
-                "blogsearch.google.kz", 
-                "blogsearch.google.la", 
-                "blogsearch.google.li", 
-                "blogsearch.google.lk", 
-                "blogsearch.google.lt", 
-                "blogsearch.google.lu", 
-                "blogsearch.google.lv", 
-                "blogsearch.google.md", 
-                "blogsearch.google.me", 
-                "blogsearch.google.mg", 
-                "blogsearch.google.mk", 
-                "blogsearch.google.ml", 
-                "blogsearch.google.mn", 
-                "blogsearch.google.ms", 
-                "blogsearch.google.mu", 
-                "blogsearch.google.mv", 
-                "blogsearch.google.mw", 
-                "blogsearch.google.ne", 
-                "blogsearch.google.nl", 
-                "blogsearch.google.no", 
-                "blogsearch.google.nr", 
-                "blogsearch.google.nu", 
-                "blogsearch.google.pl", 
-                "blogsearch.google.pn", 
-                "blogsearch.google.ps", 
-                "blogsearch.google.pt", 
-                "blogsearch.google.ro", 
-                "blogsearch.google.rs", 
-                "blogsearch.google.ru", 
-                "blogsearch.google.rw", 
-                "blogsearch.google.sc", 
-                "blogsearch.google.se", 
-                "blogsearch.google.sh", 
-                "blogsearch.google.si", 
-                "blogsearch.google.sk", 
-                "blogsearch.google.sm", 
-                "blogsearch.google.sn", 
-                "blogsearch.google.so", 
-                "blogsearch.google.st", 
-                "blogsearch.google.td", 
-                "blogsearch.google.tg", 
-                "blogsearch.google.tk", 
-                "blogsearch.google.tl", 
-                "blogsearch.google.tm", 
-                "blogsearch.google.to", 
-                "blogsearch.google.tt", 
-                "blogsearch.google.us", 
-                "blogsearch.google.vg", 
-                "blogsearch.google.vu", 
-                "blogsearch.google.ws"
+                "www.blogpulse.com"
             ], 
             "parameters": [
-                "q"
+                "query"
             ]
         }, 
         "Hooseek.com": {
@@ -3537,20 +3739,14 @@
                 "q"
             ]
         }, 
-        "soso.com": {
+        "Sogou": {
             "domains": [
+                "www.sougou.com", 
                 "www.soso.com"
             ], 
             "parameters": [
+                "query", 
                 "w"
-            ]
-        }, 
-        "Sogou": {
-            "domains": [
-                "www.sougou.com"
-            ], 
-            "parameters": [
-                "query"
             ]
         }, 
         "Hit-Parade": {
@@ -3569,6 +3765,15 @@
             ], 
             "parameters": [
                 "q"
+            ]
+        }, 
+        "Jungle Key": {
+            "domains": [
+                "junglekey.com", 
+                "junglekey.fr"
+            ], 
+            "parameters": [
+                "query"
             ]
         }, 
         "Interia": {
@@ -3598,12 +3803,12 @@
                 "key"
             ]
         }, 
-        "Clix": {
+        "Gomeo": {
             "domains": [
-                "pesquisa.clix.pt"
+                "www.gomeo.com"
             ], 
             "parameters": [
-                "question"
+                "Keywords"
             ]
         }
     }, 
@@ -3611,7 +3816,9 @@
         "Bigpond": {
             "domains": [
                 "webmail.bigpond.com", 
-                "webmail2.bigpond.com"
+                "webmail2.bigpond.com", 
+                "email.telstra.com", 
+                "basic.messaging.bigpond.com"
             ]
         }, 
         "Naver Mail": {
@@ -3619,34 +3826,14 @@
                 "mail.naver.com"
             ]
         }, 
-        "Optus Zoo": {
+        "Zoho": {
             "domains": [
-                "webmail.optuszoo.com.au"
+                "mail.zoho.com"
             ]
         }, 
-        "Seznam Mail": {
+        "Virgin": {
             "domains": [
-                "email.seznam.cz"
-            ]
-        }, 
-        "126 Mail": {
-            "domains": [
-                "mail.126.com"
-            ]
-        }, 
-        "Outlook.com": {
-            "domains": [
-                "mail.live.com"
-            ]
-        }, 
-        "AOL Mail": {
-            "domains": [
-                "mail.aol.com"
-            ]
-        }, 
-        "Daum Mail": {
-            "domains": [
-                "mail2.daum.net"
+                "webmail.virginbroadband.com.au"
             ]
         }, 
         "Yahoo! Mail": {
@@ -3657,9 +3844,104 @@
                 "mail.yahoo.co.jp"
             ]
         }, 
-        "163 Mail": {
+        "iiNet": {
             "domains": [
-                "mail.163.com"
+                "webmail.iinet.net.au", 
+                "mail.iinet.net.au"
+            ]
+        }, 
+        "E1.ru": {
+            "domains": [
+                "mail.e1.ru"
+            ]
+        }, 
+        "Vodafone": {
+            "domains": [
+                "webmail.vodafone.co.nz"
+            ]
+        }, 
+        "126 Mail": {
+            "domains": [
+                "mail.126.com"
+            ]
+        }, 
+        "Inbox.com": {
+            "domains": [
+                "inbox.com"
+            ]
+        }, 
+        "iPrimus": {
+            "domains": [
+                "webmail.iprimus.com.au"
+            ]
+        }, 
+        "QQ Mail": {
+            "domains": [
+                "mail.qq.com", 
+                "exmail.qq.com"
+            ]
+        }, 
+        "QIP": {
+            "domains": [
+                "mail.qip.ru"
+            ]
+        }, 
+        "Sibmail": {
+            "domains": [
+                "sibmail.com"
+            ]
+        }, 
+        "Freenet": {
+            "domains": [
+                "webmail.freenet.de"
+            ]
+        }, 
+        "Seznam Mail": {
+            "domains": [
+                "email.seznam.cz"
+            ]
+        }, 
+        "Westnet": {
+            "domains": [
+                "webmail.westnet.com.au"
+            ]
+        }, 
+        "Outlook.com": {
+            "domains": [
+                "mail.live.com", 
+                "outlook.live.com"
+            ]
+        }, 
+        "Dodo": {
+            "domains": [
+                "webmail.dodo.com.au"
+            ]
+        }, 
+        "2degrees": {
+            "domains": [
+                "webmail.2degreesbroadband.co.nz"
+            ]
+        }, 
+        "Daum Mail": {
+            "domains": [
+                "mail2.daum.net", 
+                "mail.daum.net"
+            ]
+        }, 
+        "Beeline": {
+            "domains": [
+                "post.ru"
+            ]
+        }, 
+        "Mail.ru": {
+            "domains": [
+                "e.mail.ru", 
+                "touch.mail.ru"
+            ]
+        }, 
+        "Adam Internet": {
+            "domains": [
+                "webmail.adam.com.au"
             ]
         }, 
         "Orange Webmail": {
@@ -3667,9 +3949,55 @@
                 "orange.fr/webmail"
             ]
         }, 
-        "QQ Mail": {
+        "AOL Mail": {
             "domains": [
-                "mail.qq.com"
+                "mail.aol.com"
+            ]
+        }, 
+        "Netspace": {
+            "domains": [
+                "webmail.netspace.net.au"
+            ]
+        }, 
+        "Optus Zoo": {
+            "domains": [
+                "webmail.optuszoo.com.au", 
+                "webmail.optusnet.com.au"
+            ]
+        }, 
+        "Commander": {
+            "domains": [
+                "webmail.commander.net.au"
+            ]
+        }, 
+        "Mastermail": {
+            "domains": [
+                "mastermail.ru", 
+                "m.mastermail.ru"
+            ]
+        }, 
+        "Yandex": {
+            "domains": [
+                "mail.yandex.ru", 
+                "mail.yandex.com", 
+                "mail.yandex.kz", 
+                "mail.yandex.ua", 
+                "mail.yandex.by"
+            ]
+        }, 
+        "163 Mail": {
+            "domains": [
+                "mail.163.com"
+            ]
+        }, 
+        "Ukr.net": {
+            "domains": [
+                "mail.ukr.net"
+            ]
+        }, 
+        "Rambler": {
+            "domains": [
+                "mail.rambler.ru"
             ]
         }, 
         "Mynet Mail": {
@@ -3679,7 +4007,272 @@
         }, 
         "Gmail": {
             "domains": [
-                "mail.google.com"
+                "mail.google.com", 
+                "inbox.google.com"
+            ]
+        }
+    }, 
+    "paid": {
+        "AdSpirit": {
+            "domains": [
+                "adspirit.de", 
+                "rtbcity.com", 
+                "plusperformance.com"
+            ]
+        }, 
+        "Flashtalking": {
+            "domains": [
+                "flashtalking.com", 
+                "servedby.flashtalking.com"
+            ]
+        }, 
+        "AudienceScience": {
+            "domains": [
+                "wunderloop.net"
+            ]
+        }, 
+        "Outbrain": {
+            "domains": [
+                "paid.outbrain.com"
+            ]
+        }, 
+        "Yieldmo": {
+            "domains": [
+                "yieldmo.com"
+            ]
+        }, 
+        "Mozo": {
+            "domains": [
+                "mozo.com.au", 
+                "a.mozo.com.au"
+            ]
+        }, 
+        "Acuity Ads": {
+            "domains": [
+                "acuityplatform.com"
+            ]
+        }, 
+        "LifeStreet": {
+            "domains": [
+                "lfstmedia.com"
+            ]
+        }, 
+        "MicroAd": {
+            "domains": [
+                "microad.jp"
+            ]
+        }, 
+        "Taboola": {
+            "domains": [
+                "trc.taboola.com", 
+                "api.taboola.com", 
+                "taboola.com"
+            ]
+        }, 
+        "Doubleclick": {
+            "domains": [
+                "ad.doubleclick.net", 
+                "ad-apac.doubleclick.net", 
+                "s0.2mdn.net", 
+                "s1.2mdn.net", 
+                "dp.g.doubleclick.net", 
+                "pubads.g.doubleclick.net"
+            ]
+        }, 
+        "Adform": {
+            "domains": [
+                "adform.net"
+            ]
+        }, 
+        "Sizmek": {
+            "domains": [
+                "bs.serving-sys.com"
+            ]
+        }, 
+        "Criteo": {
+            "domains": [
+                "cas.jp.as.criteo.com", 
+                "cas.criteo.com"
+            ]
+        }, 
+        "Fluct": {
+            "domains": [
+                "adingo.jp"
+            ]
+        }, 
+        "LowerMyBills": {
+            "domains": [
+                "lowermybills.com"
+            ], 
+            "parameters": [
+                "leadid"
+            ]
+        }, 
+        "White Pages": {
+            "domains": [
+                "www.whitepages.com.au", 
+                "mobile.whitepages.com.au"
+            ]
+        }, 
+        "Neustar AdAdvisor": {
+            "domains": [
+                "adadvisor.net"
+            ]
+        }, 
+        "ONE by AOL": {
+            "domains": [
+                "nexage.com"
+            ]
+        }, 
+        "Mixpo": {
+            "domains": [
+                "mixpo.com"
+            ]
+        }, 
+        "Rubicon Project": {
+            "domains": [
+                "optimized-by.rubiconproject.com"
+            ]
+        }, 
+        "PubMatic": {
+            "domains": [
+                "sshowads.pubmatic.com"
+            ]
+        }, 
+        "Jivox": {
+            "domains": [
+                "jivox.com"
+            ]
+        }, 
+        "BidSwitch": {
+            "domains": [
+                "bidswitch.net"
+            ]
+        }, 
+        "Sonobi": {
+            "domains": [
+                "sonobi.com"
+            ]
+        }, 
+        "SteelHouse": {
+            "domains": [
+                "steelhousemedia.com"
+            ]
+        }, 
+        "AdRoll": {
+            "domains": [
+                "adroll.com"
+            ]
+        }, 
+        "AdNET": {
+            "domains": [
+                "adnet.de"
+            ]
+        }, 
+        "Tribal Fusion": {
+            "domains": [
+                "cdnx.tribalfusion.com"
+            ]
+        }, 
+        "Yandex.Market": {
+            "domains": [
+                "market.yandex.ru", 
+                "m.market.yandex.ru"
+            ]
+        }, 
+        "StickyADS.tv": {
+            "domains": [
+                "stickyadstv.com", 
+                "sfx.stickyadstv.com"
+            ]
+        }, 
+        "ZEDO": {
+            "domains": [
+                "zedo.com", 
+                "z1.zedo.com"
+            ]
+        }, 
+        "Plista": {
+            "domains": [
+                "farm.plista.com"
+            ]
+        }, 
+        "AppNexus": {
+            "domains": [
+                "ib.adnxs.com", 
+                "adnxs.com", 
+                "247realmedia.com"
+            ]
+        }, 
+        "Sovrn": {
+            "domains": [
+                "lijit.com"
+            ]
+        }, 
+        "Google": {
+            "domains": [
+                "www.googleadservices.com", 
+                "partner.googleadservices.com", 
+                "googleads.g.doubleclick.net", 
+                "tpc.googlesyndication.com", 
+                "googleadservices.com", 
+                "imasdk.googleapis.com"
+            ]
+        }, 
+        "Eyeota": {
+            "domains": [
+                "eyeota.net"
+            ]
+        }, 
+        "Price.ru": {
+            "domains": [
+                "price.ru", 
+                "v.price.ru"
+            ]
+        }, 
+        "OpenX": {
+            "domains": [
+                "us-ads.openx.net", 
+                "openx.net", 
+                "servedbyopenx.com", 
+                "openxenterprise.com"
+            ]
+        }, 
+        "Casale Media": {
+            "domains": [
+                "casalemedia.com"
+            ]
+        }, 
+        "Adition": {
+            "domains": [
+                "adition.com"
+            ]
+        }, 
+        "Yandex.Direct": {
+            "domains": [
+                "an.yandex.ru", 
+                "yabs.yandex.ru", 
+                "yabs.yandex.ua", 
+                "yabs.yandex.com", 
+                "yabs.yandex.by"
+            ]
+        }, 
+        "ADFOX": {
+            "domains": [
+                "adfox.ru", 
+                "www.adfox.ru", 
+                "ads.adfox.ru", 
+                "www.ads.adfox.ru"
+            ]
+        }, 
+        "Torg.Mail.ru": {
+            "domains": [
+                "torg.mail.ru"
+            ]
+        }, 
+        "Sociomantic Labs": {
+            "domains": [
+                "sociomantic.com"
             ]
         }
     }, 
@@ -3712,7 +4305,7 @@
         }, 
         "Buzznet": {
             "domains": [
-                "wayn.com"
+                "buzznet.com"
             ]
         }, 
         "MyLife": {
@@ -3725,6 +4318,11 @@
                 "flickr.com"
             ]
         }, 
+        "Whirlpool": {
+            "domains": [
+                "forums.whirlpool.net.au"
+            ]
+        }, 
         "Sonico.com": {
             "domains": [
                 "sonico.com"
@@ -3732,7 +4330,8 @@
         }, 
         "Odnoklassniki": {
             "domains": [
-                "odnoklassniki.ru"
+                "odnoklassniki.ru", 
+                "ok.ru"
             ]
         }, 
         "GitHub": {
@@ -3844,12 +4443,15 @@
         }, 
         "Instagram": {
             "domains": [
-                "instagram.com"
+                "instagram.com", 
+                "l.instagram.com"
             ]
         }, 
         "Vkontakte": {
             "domains": [
+                "m.vk.com", 
                 "vk.com", 
+                "away.vk.com", 
                 "vkontakte.ru"
             ]
         }, 
@@ -3874,9 +4476,9 @@
                 "wayn.com"
             ]
         }, 
-        "Tuenti": {
+        "Skype": {
             "domains": [
-                "tuenti.com"
+                "web.skype.com"
             ]
         }, 
         "Mail.ru": {
@@ -3901,7 +4503,9 @@
         }, 
         "Pinterest": {
             "domains": [
-                "pinterest.com"
+                "pinterest.com", 
+                "pinterest.ca", 
+                "pinterest.com.au"
             ]
         }, 
         "LinkedIn": {
@@ -3937,9 +4541,8 @@
         }, 
         "Pocket": {
             "domains": [
-                "itusozluk.com"
-            ], 
-            "ITU Sozluk": null
+                "getpocket.com"
+            ]
         }, 
         "Skyrock": {
             "domains": [
@@ -3953,6 +4556,11 @@
                 "m.facebook.com", 
                 "l.facebook.com", 
                 "lm.facebook.com"
+            ]
+        }, 
+        "WhatsApp": {
+            "domains": [
+                "web.whatsapp.com"
             ]
         }, 
         "Disqus": {
@@ -3970,6 +4578,11 @@
         "Fotolog": {
             "domains": [
                 "fotolog.com"
+            ]
+        }, 
+        "ITU Sozluk": {
+            "domains": [
+                "itusozluk.com"
             ]
         }, 
         "Google+": {
@@ -3996,6 +4609,11 @@
         "Bebo": {
             "domains": [
                 "bebo.com"
+            ]
+        }, 
+        "Tuenti": {
+            "domains": [
+                "tuenti.com"
             ]
         }, 
         "Youtube": {
@@ -4053,7 +4671,8 @@
         }, 
         "Tumblr": {
             "domains": [
-                "tumblr.com"
+                "tumblr.com", 
+                "t.umblr.com"
             ]
         }, 
         "Hacker News": {

--- a/data/referers.yml
+++ b/data/referers.yml
@@ -420,7 +420,7 @@ social:
     domains:
       - getpocket.com
       
-    ITU Sozluk:
+  ITU Sozluk:
     domains:
       - itusozluk.com
       
@@ -789,12 +789,6 @@ search:
       - q
     domains:
       - search.conduit.com
-
-  Comcast:
-    parameters:
-      - q
-    domains:
-      - serach.comcast.net
 
   Crawler:
     parameters:

--- a/data/referers.yml
+++ b/data/referers.yml
@@ -8,6 +8,7 @@
 # 2. Email providers
 # 3. Social providers
 # 4. Search providers
+# 5. Paid media
 
 
 # #######################################################################################################
@@ -29,7 +30,6 @@ unknown:
       - sites.google.com
       - groups.google.com
       - groups.google.co.uk
-      - news.google.co.uk
 
   Yahoo!:
     domains:
@@ -51,15 +51,15 @@ unknown:
       - omg.yahoo.com
       - match.yahoo.net
 
-  Taboola:
+  Yandex Maps:
+    parameters:
+      - text
     domains:
-      - trc.taboola.com
-      - api.taboola.com
-
-  Outbrain:
-    domains:
-      - paid.outbrain.com
-
+      - maps.yandex.ru
+      - maps.yandex.ua
+      - maps.yandex.com
+      - maps.yandex.by
+      - n.maps.yandex.ru
 
 # #######################################################################################################
 #
@@ -75,30 +75,94 @@ email:
     domains:
       - mail.163.com
 
+  2degrees:
+    domains:
+      - webmail.2degreesbroadband.co.nz
+
+  Adam Internet:
+    domains:
+      - webmail.adam.com.au
+
   AOL Mail:
     domains:
       - mail.aol.com
+
+  Beeline:
+    domains:
+      - post.ru
 
   Bigpond:
     domains:
       - webmail.bigpond.com
       - webmail2.bigpond.com
+      - email.telstra.com
+      - basic.messaging.bigpond.com
+
+  Commander:
+    domains:
+      - webmail.commander.net.au
 
   Daum Mail:
     domains:
       - mail2.daum.net
+      - mail.daum.net
+
+  Dodo:
+    domains:
+      - webmail.dodo.com.au
+
+  E1.ru:
+    domains:
+      - mail.e1.ru
+
+  Freenet:
+    domains:
+      - webmail.freenet.de
 
   Gmail:
     domains:
       - mail.google.com
+      - inbox.google.com
+
+  iiNet:
+    domains:
+      - webmail.iinet.net.au
+      - mail.iinet.net.au
+
+  Inbox.com:
+    domains:
+      - inbox.com
+
+  iPrimus:
+    domains:
+      - webmail.iprimus.com.au
+
+  Mail.ru:
+    domains:
+      - e.mail.ru
+      - touch.mail.ru
+
+  Mastermail:
+    domains:
+      - mastermail.ru
+      - m.mastermail.ru
+
+  Mynet Mail:
+    domains:
+      - mail.mynet.com
 
   Naver Mail:
     domains:
       - mail.naver.com
 
+  Netspace:
+    domains:
+      - webmail.netspace.net.au
+
   Optus Zoo:
     domains:
-      - webmail.optuszoo.com.au  
+      - webmail.optuszoo.com.au
+      - webmail.optusnet.com.au
 
   Orange Webmail:
     domains:
@@ -107,14 +171,52 @@ email:
   Outlook.com:
     domains:
       - mail.live.com
+      - outlook.live.com
+
+  QIP:
+    domains:
+      - mail.qip.ru
 
   QQ Mail:
     domains:
-      - mail.qq.com  
+      - mail.qq.com
+      - exmail.qq.com
+
+  Rambler:
+    domains:
+      - mail.rambler.ru 
 
   Seznam Mail:
     domains:
-      - email.seznam.cz  
+      - email.seznam.cz
+
+  Sibmail:
+    domains:
+      - sibmail.com
+
+  Ukr.net:
+    domains:
+      - mail.ukr.net
+
+  Virgin:
+    domains:
+      - webmail.virginbroadband.com.au
+
+  Vodafone:
+    domains:
+      - webmail.vodafone.co.nz
+
+  Westnet:
+    domains:
+      - webmail.westnet.com.au
+
+  Yandex:
+    domains:
+      - mail.yandex.ru
+      - mail.yandex.com
+      - mail.yandex.kz
+      - mail.yandex.ua
+      - mail.yandex.by
 
   Yahoo! Mail:
     domains:
@@ -122,11 +224,10 @@ email:
       - mail.yahoo.com
       - mail.yahoo.co.uk
       - mail.yahoo.co.jp
-      
-  Mynet Mail:
-    domains:
-      - mail.mynet.com
 
+  Zoho:
+    domains:
+      - mail.zoho.com
 
 # #######################################################################################################
 #
@@ -158,6 +259,7 @@ social:
   Instagram:
     domains:
       - instagram.com
+      - l.instagram.com
 
   Youtube:
     domains:
@@ -187,7 +289,9 @@ social:
 
   Vkontakte:
     domains:
+      - m.vk.com
       - vk.com
+      - away.vk.com
       - vkontakte.ru
 
   Tagged:
@@ -250,6 +354,7 @@ social:
   Odnoklassniki:
     domains:
       - odnoklassniki.ru
+      - ok.ru
 
   Viadeo:
     domains:
@@ -326,6 +431,8 @@ social:
   Pinterest:
     domains:
       - pinterest.com
+      - pinterest.ca
+      - pinterest.com.au
 
   Plaxo:
     domains:
@@ -350,6 +457,7 @@ social:
   Tumblr:
     domains:
       - tumblr.com
+      - t.umblr.com
 
   Nasza-klasa.pl:
     domains:
@@ -373,7 +481,7 @@ social:
 
   Buzznet:
     domains:
-      - wayn.com
+      - buzznet.com
 
   Multiply:
     domains:
@@ -419,38 +527,38 @@ social:
   Pocket:
     domains:
       - getpocket.com
-      
+
   ITU Sozluk:
     domains:
       - itusozluk.com
-      
+
   Instela:
     domains:
       - instela.com
-      
+
   Eksi Sozluk:
     domains:
       - Sozluk.com
       - sourtimes.org
-  
+
   Uludag Sozluk:
     domains:
       - uludagsozluk.com
       - ulusozluk.com
-  
+
   Inci Sozluk:
     domains:
       - inci.sozlukspot.com
       - incisozluk.com
       - incisozluk.cc
-  
+
   Hocam.com:
     domains:
       - hocam.com
-      
+
   Donanimhaber:
     domains:
-      - donanimhaber.com 
+      - donanimhaber.com
 
   Disqus:
     domains:
@@ -461,6 +569,18 @@ social:
   Quora:
     domains:
       - quora.com
+
+  Skype:
+    domains:
+      - web.skype.com
+
+  WhatsApp:
+    domains:
+      - web.whatsapp.com
+
+  Whirlpool:
+    domains:
+      - forums.whirlpool.net.au
 
 # #######################################################################################################
 #
@@ -476,11 +596,24 @@ search:
 
   # 123people TODO
 
+  1&1:
+    parameters:
+      - q
+    domains:
+      - search.1and1.com
+
   1und1:
     parameters:
       - su
     domains:
       - search.1und1.de
+
+  2gis:
+    domains:
+      - 2gis.ru
+      - www.2gis.ru
+      - link.2gis.ru
+      - www.link.2gis.ru
 
   360.cn:
     parameters:
@@ -575,6 +708,7 @@ search:
       - www.aolimages.aol.fr
       - aim.search.aol.com
       - www.recherche.aol.fr
+      - recherche.aol.fr
       - find.web.aol.com
       - recherche.aol.ca
       - aolsearch.aol.co.uk
@@ -696,6 +830,7 @@ search:
       - tieba.baidu.com
       - news.baidu.com
       - web.gougou.com
+      - m.baidu.com
 
   Biglobe:
     parameters:
@@ -747,6 +882,12 @@ search:
     domains:
       - search.bluewin.ch
 
+  British Telecommunications:
+    parameters:
+      - p
+    domains:
+      - search.bt.com
+
   canoe.ca:
     parameters:
       - q
@@ -778,17 +919,17 @@ search:
     domains:
       - pesquisa.clix.pt
 
-  Comcast:
-    parameters:
-      - q
-    domains:
-      - search.comcast.net
-
   Conduit:
     parameters:
       - q
     domains:
       - search.conduit.com
+
+  Comcast:
+    parameters:
+      - q
+    domains:
+      - serach.comcast.net
 
   Crawler:
     parameters:
@@ -863,6 +1004,12 @@ search:
     domains:
       - dmoz.org
       - editors.dmoz.org
+
+  Dodo:
+    parameters:
+      - q
+    domains:
+      - google.dodo.com.au
 
   DuckDuckGo:
     parameters:
@@ -945,6 +1092,12 @@ search:
       - name
     domains:
       - recherche.francite.com
+
+  Finderoo:
+    parameters:
+      - q
+    domains:
+      - www.finderoo.com
 
   Findwide:
     parameters:
@@ -1175,7 +1328,6 @@ search:
       - www.google.jo
       - www.google.co.jp
       - www.google.co.ke
-      - www.google.com.kh
       - www.google.ki
       - www.google.kg
       - www.google.co.kr
@@ -1256,6 +1408,7 @@ search:
       - www.google.tm
       - www.google.to
       - www.google.com.tn
+      - www.google.tn
       - www.google.com.tr
       - www.google.tt
       - www.google.com.tw
@@ -1372,7 +1525,6 @@ search:
       - google.jo
       - google.co.jp
       - google.co.ke
-      - google.com.kh
       - google.ki
       - google.kg
       - google.co.kr
@@ -1474,6 +1626,7 @@ search:
       - google.co.za
       - google.co.zm
       - google.co.zw
+      - google.tn
       # powered by Google
       - search.avg.com
       - isearch.avg.com
@@ -1585,7 +1738,6 @@ search:
       - blogsearch.google.com.gt
       - blogsearch.google.com.hk
       - blogsearch.google.com.jm
-      - blogsearch.google.com.kh
       - blogsearch.google.com.kh
       - blogsearch.google.com.kw
       - blogsearch.google.com.lb
@@ -1984,7 +2136,6 @@ search:
       - images.google.com.hk
       - images.google.com.jm
       - images.google.com.kh
-      - images.google.com.kh
       - images.google.com.kw
       - images.google.com.lb
       - images.google.com.lc
@@ -2104,7 +2255,6 @@ search:
       - images.google.us
       - images.google.vg
       - images.google.vu
-      - images.google.ws
 
   Google News:
     parameters:
@@ -2185,7 +2335,6 @@ search:
       - news.google.com.gt
       - news.google.com.hk
       - news.google.com.jm
-      - news.google.com.kh
       - news.google.com.kh
       - news.google.com.kw
       - news.google.com.lb
@@ -2388,7 +2537,6 @@ search:
       - google.com.hk/products
       - google.com.jm/products
       - google.com.kh/products
-      - google.com.kh/products
       - google.com.kw/products
       - google.com.lb/products
       - google.com.lc/products
@@ -2585,7 +2733,6 @@ search:
       - www.google.com.hk/products
       - www.google.com.jm/products
       - www.google.com.kh/products
-      - www.google.com.kh/products
       - www.google.com.kw/products
       - www.google.com.lb/products
       - www.google.com.lc/products
@@ -2776,6 +2923,21 @@ search:
     domains:
       - www.ilse.nl
 
+  Inbox.com:
+    parameters:
+      - q
+    domains:
+      - inbox.com/search/
+
+  Indeed:
+    domains:
+      - de.indeed.com
+      - at.indeed.com
+      - fr.indeed.com
+      - it.indeed.com
+      - ch.indeed.com
+      - au.indeed.com
+
   InfoSpace:
     parameters:
       - q
@@ -2795,6 +2957,13 @@ search:
       - search.searchcompletion.com
       - clusty.com
 
+  Flyingbird:
+    parameters:
+      - q
+    domains:
+      - inspsearch.com
+      - viview.inspsearch.com
+
   Interia:
     parameters:
       - q
@@ -2806,6 +2975,12 @@ search:
       - q
     domains:
       - start.iplay.com
+
+  I.ua:
+    parameters:
+      - q
+    domains:
+      - search.i.ua
 
   IXquick:
     parameters:
@@ -2856,6 +3031,12 @@ search:
     domains:
       - www.kvasir.no
 
+  kununu:
+    parameters:
+      - q
+    domains:
+      - kununu.com
+
   Latne:
     parameters:
       - q
@@ -2868,6 +3049,18 @@ search:
     domains:
       - www.toile.com
       - web.toile.com
+
+  Lilo:
+    parameters:
+      - q
+    domains:
+      - search.lilo.org
+
+  Liveinternet:
+    parameters:
+      - q
+    domains:
+      - liveinternet.ru
 
   Looksmart:
     parameters:
@@ -2899,6 +3092,8 @@ search:
     parameters:
       - q
     domains:
+      - mail.ru
+      - m.mail.ru
       - go.mail.ru
 
   Mamma:
@@ -2960,6 +3155,21 @@ search:
       - www.mister-wong.com
       - www.mister-wong.de
 
+  Monster:
+    parameters:
+      - q
+    domains:
+      - www.monster.be
+      - www.monster.cz
+      - www.monster.de
+      - www.monster.fi
+      - www.monster.fr
+      - www.monster.ie
+      - www.monster.it
+      - www.monster.lu
+      - www.monster.ch
+      - www.monster.co.uk
+
   Monstercrawler:
     parameters:
       - qry
@@ -2985,6 +3195,7 @@ search:
       - searchfor
       - searchFor
     domains:
+      - mysearch.com
       - www.mysearch.com
       - ms114.mysearch.com
       - ms146.mysearch.com
@@ -3063,9 +3274,11 @@ search:
   Orange:
     parameters:
       - q
+      - kw
     domains:
       - busca.orange.es
       - search.orange.co.uk
+      - lemoteur.orange.fr
 
   Paperball:
     parameters:
@@ -3095,7 +3308,7 @@ search:
     parameters:
       - q
     domains:
-      - www.plazoo.com
+      - poisk.ru
 
   PriceRunner:
     parameters:
@@ -3117,6 +3330,13 @@ search:
       - www.qualigo.ch
       - www.qualigo.de
       - www.qualigo.nl
+
+  Qwant:
+    parameters:
+      - q
+    domains:
+      - www.qwant.com
+      - lite.qwant.com
 
   Rakuten:
     parameters:
@@ -3151,6 +3371,12 @@ search:
       - pesquisa.sapo.pt
 
   # Add Scour.com
+
+  Search This:
+    parameters:
+      - q
+    domains:
+      - www.searchthis.com
 
   Search.com:
     parameters:
@@ -3202,11 +3428,20 @@ search:
     domains:
       - www.skynet.be
 
+  The Smart Search:
+    parameters:
+      - q
+    domains:
+      - thesmartsearch.net
+      - www.thesmartsearch.net
+
   Sogou:
     parameters:
       - query
+      - w
     domains:
       - www.sougou.com
+      - www.soso.com
 
   Softonic:
     parameters:
@@ -3214,11 +3449,24 @@ search:
     domains:
       - search.softonic.com
 
-  soso.com:
+  SoSoDesk:
     parameters:
-      - w
+      - q
     domains:
-      - www.soso.com
+      - sosodesktop.com
+      - search.sosodesktop.com
+
+  Shenma:
+    parameters:
+      - q
+    domains:
+      - so.m.sm.cn
+      - yz.m.sm.cn
+      - m.sm.cn
+      - quark.sm.cn
+      - m.sp.sm.cn
+      - m.yz2.sm.cn
+      - m.yz.sm.cn
 
   Snapdo:
     parameters:
@@ -3237,6 +3485,16 @@ search:
       - q
     domains:
       - www.startsiden.no
+
+  StepStone:
+    domains:
+      - www.stepstone.de
+      - www.stepstone.at
+      - www.stepstone.be
+      - www.stepstone.fr
+      - www.stepstone.nl
+      - www.stepstone.dk
+      - www.stepstone.se
 
   suche.info:
     parameters:
@@ -3267,6 +3525,12 @@ search:
       - q
     domains:
       - technorati.com
+
+  Telstra:
+    parameters:
+      - find
+    domains:
+      - search.media.telstra.com.au
 
   Teoma:
     parameters:
@@ -3330,11 +3594,23 @@ search:
     domains:
       - www.trusted--search.com
 
+  Tut.by:
+    parameters:
+      - query
+    domains:
+      - search.tut.by
+
   Twingly:
     parameters:
       - q
     domains:
       - www.twingly.com
+
+  UKR.net:
+    parameters:
+      - q
+    domains:
+      - search.ukr.net
 
   uol.com.br:
     parameters:
@@ -3462,6 +3738,8 @@ search:
       - au.yahoo.com
       - br.search.yahoo.com
       - br.yahoo.com
+      - ca.search.yahoo.com
+      - ca.yahoo.com
       - cade.searchde.yahoo.com
       - cade.yahoo.com
       - chinese.searchinese.yahoo.com
@@ -3475,13 +3753,15 @@ search:
       - es.search.yahoo.com
       - es.yahoo.com
       - espanol.searchpanol.yahoo.com
-      - espanol.searchpanol.yahoo.com
-      - espanol.yahoo.com
       - espanol.yahoo.com
       - fr.search.yahoo.com
       - fr.yahoo.com
+      - hk.search.yahoo.com
+      - hk.yahoo.com
       - ie.search.yahoo.com
       - ie.yahoo.com
+      - in.search.yahoo.com
+      - in.yahoo.com
       - it.search.yahoo.com
       - it.yahoo.com
       - kr.search.yahoo.com
@@ -3495,17 +3775,18 @@ search:
       - one.cn.yahoo.com
       - one.searchn.yahoo.com
       - qc.search.yahoo.com
-      - qc.search.yahoo.com
-      - qc.search.yahoo.com
       - qc.yahoo.com
-      - qc.yahoo.com
-      - se.search.yahoo.com
+      - ru.search.yahoo.com
+      - ru.yahoo.com
       - se.search.yahoo.com
       - se.yahoo.com
       - search.searcharch.yahoo.com
-      - search.yahoo.com
+      - tw.search.yahoo.com
+      - tw.yahoo.com
       - uk.search.yahoo.com
       - uk.yahoo.com
+      - us.search.yahoo.com
+      - us.yahoo.com
       - www.yahoo.co.jp
       - search.yahoo.co.jp
       # powered by Yahoo
@@ -3539,6 +3820,10 @@ search:
       - www.yandex.ua
       - www.yandex.com
       - www.yandex.by
+      - clck.yandex.ru
+      - clck.yandex.ua
+      - clck.yandex.com
+      - clck.yandex.by
 
   Yandex Images:
     parameters:
@@ -3547,6 +3832,7 @@ search:
       - images.yandex.ru
       - images.yandex.ua
       - images.yandex.com
+      - images.yandex.by
 
   Yasni:
     parameters:
@@ -3613,3 +3899,227 @@ search:
       - q
     domains:
       - zoohoo.cz
+
+
+
+# #######################################################################################################
+#
+# PAID MEDIA
+
+paid:
+
+  Acuity Ads:
+    domains:
+      - acuityplatform.com
+
+  Adform:
+    domains:
+      - adform.net
+
+  ADFOX:
+    domains:
+      - adfox.ru
+      - www.adfox.ru
+      - ads.adfox.ru
+      - www.ads.adfox.ru
+
+  Adition:
+    domains:
+      - adition.com
+
+  AdNET:
+    domains:
+      - adnet.de
+
+  AdRoll:
+    domains:
+      - adroll.com
+
+  AdSpirit:
+    domains:
+      - adspirit.de
+      - rtbcity.com
+      - plusperformance.com
+
+  AppNexus:
+    domains:
+      - ib.adnxs.com
+      - adnxs.com
+      - 247realmedia.com
+
+  AudienceScience:
+    domains:
+      - wunderloop.net
+
+  BidSwitch:
+    domains:
+      - bidswitch.net
+
+  Casale Media:
+    domains:
+      - casalemedia.com
+
+  Criteo:
+    domains:
+      - cas.jp.as.criteo.com
+      - cas.criteo.com
+
+  Doubleclick:
+    domains:
+      - ad.doubleclick.net
+      - ad-apac.doubleclick.net
+      - s0.2mdn.net
+      - s1.2mdn.net
+      - dp.g.doubleclick.net
+      - pubads.g.doubleclick.net
+
+  Eyeota:
+    domains:
+      - eyeota.net
+
+  Flashtalking:
+    domains:
+      - flashtalking.com
+      - servedby.flashtalking.com
+
+  Fluct:
+    domains:
+      - adingo.jp
+
+  Google:
+    domains:
+      - www.googleadservices.com
+      - partner.googleadservices.com
+      - googleads.g.doubleclick.net
+      - tpc.googlesyndication.com
+      - googleadservices.com
+      - imasdk.googleapis.com
+
+  LifeStreet:
+    domains:
+      - lfstmedia.com
+
+  LowerMyBills:
+    parameters:
+      - leadid
+    domains:
+      - lowermybills.com
+
+  Jivox:
+    domains:
+      - jivox.com
+
+  MicroAd:
+    domains:
+      - microad.jp
+
+  Mixpo:
+    domains:
+      - mixpo.com
+
+  Mozo:
+    domains:
+      - mozo.com.au
+      - a.mozo.com.au
+
+  Neustar AdAdvisor:
+    domains:
+      - adadvisor.net
+
+  ONE by AOL:
+    domains:
+      - nexage.com
+
+  OpenX:
+    domains:
+      - us-ads.openx.net
+      - openx.net
+      - servedbyopenx.com
+      - openxenterprise.com
+
+  Outbrain:
+    domains:
+      - paid.outbrain.com
+
+  Plista:
+    domains:
+      - farm.plista.com
+
+  Price.ru:
+    domains:
+      - price.ru
+      - v.price.ru
+
+  PubMatic:
+    domains:
+      - sshowads.pubmatic.com
+
+  Rubicon Project:
+    domains:
+      - optimized-by.rubiconproject.com
+
+  Sizmek:
+    domains:
+      - bs.serving-sys.com
+
+  Sociomantic Labs:
+    domains:
+      - sociomantic.com
+
+  Sonobi:
+    domains:
+      - sonobi.com
+
+  Sovrn:
+    domains:
+      - lijit.com
+
+  SteelHouse:
+    domains:
+      - steelhousemedia.com
+
+  StickyADS.tv:
+    domains:
+      - stickyadstv.com
+      - sfx.stickyadstv.com
+
+  Taboola:
+    domains:
+      - trc.taboola.com
+      - api.taboola.com
+      - taboola.com
+
+  Torg.Mail.ru:
+    domains:
+      - torg.mail.ru
+
+  Tribal Fusion:
+    domains:
+      - cdnx.tribalfusion.com
+
+  White Pages:
+    domains:
+      - www.whitepages.com.au
+      - mobile.whitepages.com.au
+
+  Yandex.Direct:
+    domains:
+      - an.yandex.ru
+      - yabs.yandex.ru
+      - yabs.yandex.ua
+      - yabs.yandex.com
+      - yabs.yandex.by
+
+  Yandex.Market:
+    domains:
+      - market.yandex.ru
+      - m.market.yandex.ru
+
+  Yieldmo:
+    domains:
+      - yieldmo.com
+
+  ZEDO:
+    domains:
+      - zedo.com
+      - z1.zedo.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1555 @@
+{
+  "name": "referer-parser",
+  "version": "0.0.4",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "referer-parser",
+      "version": "0.0.4",
+      "dependencies": {
+        "js-yaml": "^4.1.0"
+      },
+      "devDependencies": {
+        "mocha": "~10.2.0"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/mocha/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  },
+  "dependencies": {
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true
+    },
+    "diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^5.0.0"
+      }
+    },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      }
+    },
+    "minimatch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^2.0.1"
+      }
+    },
+    "mocha": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
+    "p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^3.0.2"
+      }
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
+    "serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true
+    },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     }
   ],
   "dependencies": {
-    "js-yaml": "~2.1.0"
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
-    "mocha": "~1.12.0"
+    "mocha": "~10.2.0"
   }
 }


### PR DESCRIPTION
Fixes vulnerabilities by running `npm audit fix --force`, which updates `js-yaml` and `mocha` to the latest versions.

Test:

```
$ npm test
> referer-parser@0.0.4 test
> make test
  .......................
  23 passing (8ms)
```

Referer databases have been updated with the most up to date versions from:

- https://s3-eu-west-1.amazonaws.com/snowplow-hosted-assets/third-party/referer-parser/referers-latest.yaml 
- https://s3-eu-west-1.amazonaws.com/snowplow-hosted-assets/third-party/referer-parser/referers-latest.json